### PR TITLE
Reset minigames counter after the game is restarted

### DIFF
--- a/Blueprint/app/src/main/java/com/manhattan/blueprint/Controller/MapViewActivity.java
+++ b/Blueprint/app/src/main/java/com/manhattan/blueprint/Controller/MapViewActivity.java
@@ -225,7 +225,7 @@ public class MapViewActivity extends AppCompatActivity implements OnMapReadyCall
                     session.isHololensConnected(),
                     session.isTutorialEnabled(),
                     0,
-                    false));
+                    session.isHelpEnabled()));
         });
 
         // Check ARcore availability


### PR DESCRIPTION
Previously, if the user played 4 mini-games and restarted the app, `System.exit(0)` would be called after the 5th one. Now the counter is reset after every app restart.